### PR TITLE
Update readme with specific esp32 version

### DIFF
--- a/firmware/readme.md
+++ b/firmware/readme.md
@@ -4,7 +4,7 @@
 
 ```bash
 arduino-cli config add board_manager.additional_urls https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-arduino-cli core install esp32:esp32
+arduino-cli core install esp32:esp32@2.0.17
 ```
 
 ### Get board details


### PR DESCRIPTION
Update the readme for the OpenGlass firmware with the specific version of Expressif Arduino esp32 platform to install